### PR TITLE
バリデーションを128文字から24文字に修正

### DIFF
--- a/app/(app)/setup/index.tsx
+++ b/app/(app)/setup/index.tsx
@@ -18,7 +18,7 @@ const nameSchema = z.object({
         issue.input === undefined ? "required_error" : "invalid_type_error",
     })
     .min(3, { message: "too_short_error" })
-    .max(128, { message: "too_long_error" }),
+    .max(24, { message: "too_long_error" }),
 });
 type FormData = z.infer<typeof nameSchema>;
 

--- a/schemas/app.ts
+++ b/schemas/app.ts
@@ -20,7 +20,7 @@ export const profileSchema = z.object({
         issue.input === undefined ? "required_error" : "invalid_type_error",
     })
     .min(3, { message: "too_short_error" })
-    .max(128, {
+    .max(24, {
       message: "too_long_error",
     }),
   gender: z.enum(genders, { error: "required_error" }).nullable(),


### PR DESCRIPTION
## 議論/問題提起の場所
<!--
  Github issue, Discord, GoogleDocなど、このPRの根拠となるソースを書く
  なければこのPRを作成した背景と経緯を書く
-->

## 概要
<!-- 変更内容を書く -->
setupにおけるname登録において、24文字を意図してエラーメッセージには「ユーザー名は24文字以内で入力してください。」と出力するようにしていたが、実装上では128文字を超えるとエラーを吐くような実装になっていた。

## やっていないこと
<!-- このPRではやっていないことを書く -->

## 動作確認
<!-- 実装した機能の再現方法を書き、レビュワーが確認 -->
以下がチェックされていることを確認してください。
- [x] 25文字以上でバリデーションエラーとなり、「ユーザー名は24文字以内で入力してください。」が表示されていること

## 備考
<!-- このPRに関するレビューの助けになる情報があれば書く -->
