### PR TITLE
fix: Safe area insetsを考慮したボトムパディングの修正

### DIFF
--- a/app/(auth)/index.tsx
+++ b/app/(auth)/index.tsx
@@ -1,12 +1,14 @@
 import { useRouter } from "expo-router";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { H1, Text, YStack } from "tamagui";
 import { Button } from "@/components/Button";
 
 const TopPage = memo(() => {
   const { t } = useTranslation("top");
   const router = useRouter();
+  const insets = useSafeAreaInsets();
 
   return (
     <YStack
@@ -15,7 +17,7 @@ const TopPage = memo(() => {
       justify="space-between"
       pt="$80"
       px="$8"
-      pb="$8"
+      pb={insets.bottom + 8}
     >
       <YStack gap="$4">
         <H1


### PR DESCRIPTION
## 議論/問題提起の場所
<!--
  Github issue, Discord, GoogleDocなど、このPRの根拠となるソースを書く
  なければこのPRを作成した背景と経緯を書く
-->

## 概要
<!-- 変更内容を書く -->
- ログイン、新規登録選択画面で画面下部のパディングがAndroidでは対応されていなかったため修正
## やっていないこと
<!-- このPRではやっていないことを書く -->

## 動作確認
<!-- 実装した機能の再現方法を書き、レビュワーが確認 -->
以下がチェックされていることを確認してください。
- [ ] hogehoge

## 備考
<!-- このPRに関するレビューの助けになる情報があれば書く -->
